### PR TITLE
ci: remove node feed from GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,6 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           FEEDNAME: manysecured
-          # | will get replaced with " "
-          EXTRA_FEEDS: src-git|node|https://github.com/nxhack/openwrt-node-packages.git
           # we have to pass a key, otherwise OpenWRT build fails
           # see https://forum.openwrt.org/t/cant-compile-ipk-with-sdk-key-build-signing-key-is-missing/2266
           KEY_BUILD: ${{ secrets.USIGN_KEY_BUILD }}


### PR DESCRIPTION
None of our OpenWRT packages in this repo use Node.JS, so there's no point in using the
Node.JS feed.