### PR TITLE
edgesec: move hostapd & dnsmasq to EXTRA_DEPENDS

### DIFF
--- a/edgesec/Makefile
+++ b/edgesec/Makefile
@@ -26,7 +26,8 @@ define Package/edgesec
   CATEGORY:=Network
   TITLE:=edgesec
   URL:=https://github.com/nqminds/EDGESec
-  DEPENDS:=hostapd +dnsmasq +libuuid +libuci +libsqlite3 +libpcap
+  DEPENDS:=+libuuid +libuci +libsqlite3 +libpcap
+  EXTRA_DEPENDS=hostapd, dnsmasq
 endef
 
 define Package/edgesec/description


### PR DESCRIPTION
As far as I can tell, both of these aren't needed for building edgesec, since we just call their binaries.