### PR TITLE
ssh-legion: create /etc/machine-id on first boot

### DIFF
--- a/ssh-legion/Makefile
+++ b/ssh-legion/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ssh-legion
 PKG_VERSION:=0.1.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nqminds/ssh-legion.git
@@ -66,6 +66,11 @@ define Package/ssh-legion/install
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/ssh-legion.init.sh $(1)/etc/init.d/ssh-legion
+
+	# creates an /etc/machine-id on first boot
+	# tried to use dbus-uuidgen, or uuidgen, or fallsback to busybox and /dev/urandom
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/setup-machine-id $(1)/etc/uci-defaults/95-setup-machine-id
 
 	$(INSTALL_DIR) $(1)/etc/ssh-legion
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/ssh-legion.config $(1)/etc/ssh-legion/ssh-legion.config

--- a/ssh-legion/files/setup-machine-id
+++ b/ssh-legion/files/setup-machine-id
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Setup /etc/machine-id and /var/lib/dbus/machine-id if they don't exist
+
+# If dbus is installed, use dbus-uuidgen
+# If uuidgen is installed, use uuidgen
+# Otherwise, just create hex from random data
+
+if [ ! -f /etc/machine-id ]; then
+    if command -v dbus-uuidgen; then
+        dbus-uuidgen --ensure=/etc/machine-id
+    elif command -v uuidgen; then
+        uuidgen | sed -e 's/-//g' > /etc/machine-id
+    else
+        # nowhere near as good as uuidgen, but probably doesn't matter
+        # too much
+        tr -dc 'a-f0-9' < /dev/urandom | head -c32 > /etc/machine-id
+        # add trailing \n char
+        echo "" >> /etc/machine-id
+    fi
+fi
+
+if [ ! -f /var/lib/dbus/machine-id ]; then
+    mkdir -p /var/lib/dbus
+    ln -s /etc/machine-id /var/lib/dbus/machine-id
+fi


### PR DESCRIPTION
On first boot, sets up the `/etc/machine-id` file by using:

- `dbus-uuidgen` (how it's supposed to be created), or
- `uuidgen` (not ideal, but should still be okay), or
- `busybox`'s `tr` command with data from `/dev/urandom`

This should allow ssh-legion to use a consistent port, as there would be a consistent `/etc/machine-id` file.

~Currently a draft, since I haven't fully tested this on an OpenWRT device.~ Confirmed working.