### PR TITLE
ssh-legion: add missing dependency on openssl-util

### DIFF
--- a/ssh-legion/Makefile
+++ b/ssh-legion/Makefile
@@ -26,7 +26,7 @@ define Package/ssh-legion
   TITLE:=Automatic reverse SSH tunnel for multiple IoT devices.
   URL:=https://github.com/nqminds/ssh-legion
   # runtime only dependency (not used to build)
-  EXTRA_DEPENDS:=openssh-client, bash (>=4.3-1)
+  EXTRA_DEPENDS:=openssh-client, bash (>=4.3-1), openssl-util (>=1.1.1-1)
   # works on all architectures since it's just a script
   PKGARCH:=all
 endef


### PR DESCRIPTION
ssh-legion runs the openssl binary, which on OpenWRT, is found in the openssl-util package, see
https://github.com/openwrt/openwrt/blob/b2681e584c0674788fc1f11dd9950cb769d961e9/package/libs/openssl/Makefile#L393-L396