### PR TITLE
edgesec: create `/srv/edgesec` folder on install

### DIFF
--- a/edgesec/Makefile
+++ b/edgesec/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=edgesec
 PKG_VERSION:=0.0.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nqminds/edgesec.git
@@ -72,6 +72,11 @@ define Package/edgesec/install
 
 	$(INSTALL_DIR) $(1)/etc/edgesec
 	$(INSTALL_CONF) ./files/config.ini $(1)/etc/edgesec
+	
+	# default folder for storing edgesec databases
+	# Warning!! Will error if `/srv` does not exist
+	# Normally, this should be external storage, not internal storage
+	$(INSTALL_DIR) $(1)/srv/edgesec
 endef
 
 $(eval $(call BuildPackage,edgesec))


### PR DESCRIPTION
Creates the `/srv/edgesec` folder on installation.
Does **NOT** create the `/srv` folder if it does not exist.

`/srv` should be some sort of long-life media, e.g. not internal flash, but an external disk/SSD, hence why we don't create `/srv`.

Work around until https://github.com/nqminds/edgesec/pull/168 is merged and released.