### PR TITLE
ci: add basic support for running test.sh scripts

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0
+# Originally from https://github.com/openwrt/packages/blob/d36c34f9847d20450f61c955ccab745a5c90e90f/.github/workflows/Dockerfile
+
+ARG ARCH=x86-64
+FROM openwrt/rootfs:$ARCH
+
+ADD entrypoint.sh /entrypoint.sh
+
+CMD ["/entrypoint.sh"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
           - arch: arm_cortex-a9_vfpv3-d16
             target: mvebu-cortexa9 # mvebu-cortexa9: turris omnia
             runtime_test: true
+          - arch: aarch64_cortex-a53
+            target: bcm27xx # Raspberry Pi 2 and 3
+            runtime_test: true
           - arch: mipsel_24kc # ath79-generic: https://openwrt.org/toh/hwdata/tp-link/tp-link_eap225-outdoor_v1
             target: ath79-generic
             runtime_test: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0
+# Contains code from https://github.com/openwrt/packages/blob/d36c34f9847d20450f61c955ccab745a5c90e90f/.github/workflows/formal.yml
+
 name: Test Build
 
 on:
@@ -6,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  BRANCH: openwrt-22.03
+
 jobs:
   build:
     name: ${{ matrix.arch }} build
@@ -13,10 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch:
-          - x86_64
-          - arm_cortex-a9_vfpv3-d16 # mvebu-cortexa9: turris omnia
-          - mipsel_24kc # ath79-generic: https://openwrt.org/toh/hwdata/tp-link/tp-link_eap225-outdoor_v1
+        include:
+          - arch: x86_64
+            target: x86_64
+            runtime_test: true
+          - arch: arm_cortex-a9_vfpv3-d16
+            target: mvebu-cortexa9 # mvebu-cortexa9: turris omnia
+            runtime_test: true
+          - arch: mipsel_24kc # ath79-generic: https://openwrt.org/toh/hwdata/tp-link/tp-link_eap225-outdoor_v1
+            target: ath79-generic
+            runtime_test: false
 
     steps:
       - uses: actions/checkout@v3
@@ -30,14 +42,64 @@ jobs:
         # use custom fork for podman-docker support
         # uses: aloisklink/gh-action-sdk@7be9a7838e0f8a99638eaf257c0322f97a7546c5
         env:
-          ARCH: ${{ matrix.arch }}
+          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: manysecured
           # we have to pass a key, otherwise OpenWRT build fails
           # see https://forum.openwrt.org/t/cant-compile-ipk-with-sdk-key-build-signing-key-is-missing/2266
           KEY_BUILD: ${{ secrets.USIGN_KEY_BUILD }}
           ARTIFACTS_DIR: ${{ runner.temp }}/artifacts
+
+      - name: Move created packages to project dir
+        run: cp ${{ runner.temp }}/artifacts/bin/packages/${{ matrix.arch }}/manysecured/*.ipk . || true
+
+      - name: Collect metadata
+        run: |
+          MERGE_ID=$(git rev-parse --short HEAD)
+          echo "MERGE_ID=$MERGE_ID" >> $GITHUB_ENV
+          echo "BASE_ID=$(git rev-parse --short HEAD^1)" >> $GITHUB_ENV
+          echo "HEAD_ID=$(git rev-parse --short HEAD^2)" >> $GITHUB_ENV
+          PRNUMBER=${GITHUB_REF_NAME%/merge}
+          echo "PRNUMBER=$PRNUMBER" >> $GITHUB_ENV
+          echo "ARCHIVE_NAME=${{matrix.arch}}-PR$PRNUMBER-$MERGE_ID" >> $GITHUB_ENV
+      - name: Generate metadata
+        run: |
+          cat << _EOF_ > PKG-INFO
+          Metadata-Version: 2.1
+          Name: ${{matrix.arch}}-packages
+          Version: $BRANCH
+          Author: $GITHUB_ACTOR
+          Home-page: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA
+          Download-URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          Summary: Manysecured Packages
+          Platform: ${{ matrix.arch }}
+          Packages for OpenWrt $BRANCH running on ${{matrix.arch}}, built from commit $GITHUB_SHA
+
+          echo >> PKG-INFO
+          echo Full file listing: >> PKG-INFO
+          ls -al *.ipk >> PKG-INFO || true
+          cat PKG-INFO
+
       - name: Store packages
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.arch}}-packages
-          path: ${{ runner.temp }}/artifacts/bin/packages/${{ matrix.arch }}/manysecured/*.ipk
+          name: ${{matrix.arch}}-packages
+          path: |
+            *.ipk
+            PKG-INFO
+
+      # testing steps
+      - name: Register QEMU container support
+        if: ${{ matrix.runtime_test }}
+        uses: dbhi/qus/action@9e6e7a40952256574dcbe6f54eac6ef984bad5c1
+
+      - name: Build Docker container
+        if: ${{ matrix.runtime_test }}
+        run: |
+          docker build -t test-container --build-arg ARCH .github/workflows/
+        env:
+          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
+
+      - name: Test via Docker container
+        if: ${{ matrix.runtime_test }}
+        run: |
+          docker run --rm -v $GITHUB_WORKSPACE:/ci test-container

--- a/.github/workflows/ci_helpers.sh
+++ b/.github/workflows/ci_helpers.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Originally from https://github.com/openwrt/packages/blob/d36c34f9847d20450f61c955ccab745a5c90e90f/.github/workflows/Dockerfile
+
+color_out() {
+	printf "\e[0;$1m$PKG_NAME: %s\e[0;0m\n" "$2"
+}
+
+success() {
+	color_out 32 "$1"
+}
+
+info() {
+	color_out 36 "$1"
+}
+
+err() {
+	color_out 31 "$1"
+}
+
+warn() {
+	color_out 33 "$1"
+}
+
+err_die() {
+	err "$1"
+	exit 1
+}

--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Originally from https://github.com/openwrt/packages/blob/d36c34f9847d20450f61c955ccab745a5c90e90f/.github/workflows/entrypoint.sh
+
+mkdir -p /var/lock/
+
+opkg update
+
+[ -n "$CI_HELPER" ] || CI_HELPER="/ci/.github/workflows/ci_helpers.sh"
+
+for PKG in /ci/*.ipk; do
+	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control
+	# package name including variant
+	PKG_NAME=$(sed -ne 's#^Package: \(.*\)$#\1#p' ./control)
+	# package version without release
+	PKG_VERSION=$(sed -ne 's#^Version: \(.*\)-[0-9]*$#\1#p' ./control)
+	# package source contianing test.sh script
+	PKG_SOURCE=$(sed -ne 's#^Source: .*/\(.*\)$#\1#p' ./control)
+
+	echo "Testing package $PKG_NAME in version $PKG_VERSION from $PKG_SOURCE"
+
+	opkg install "$PKG"
+
+	export PKG_NAME PKG_VERSION CI_HELPER
+
+	# we can't use `-not` since busybox find doesn't support it
+	TEST_SCRIPT=$(find /ci/ -name "$PKG_SOURCE" -type d '!' '(' -path '*/\.git/*' ')')/test.sh
+
+	if [ -f "$TEST_SCRIPT" ]; then
+		echo "Use package specific test.sh"
+		if sh "$TEST_SCRIPT" "$PKG_NAME" "$PKG_VERSION"; then
+			echo "Test successful"
+		else
+			echo "Test failed"
+			exit 1
+		fi
+	else
+		echo "No test.sh script found at $TEST_SCRIPT"
+	fi
+
+	opkg remove "$PKG_NAME" --force-removal-of-dependent-packages --force-remove
+done

--- a/edgesec/test.sh
+++ b/edgesec/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+PKG_NAME="$1"
+PKG_VERSION="$2"
+
+# should print edgesec version number
+edgesec -v


### PR DESCRIPTION
Adds some basic testing using `test.sh` scripts, which are locating in each package next to their `Makefile`. These tests are then run in an emulated OpenWRT 22.03 system on both x86_64 and `arm_cortex-a9_vfpv3-d16` (e.g. the Turris Omnia's CPU architecture).

For example, in the `edgesec/test.sh`, I just ran `edgesec -v`, which is a very basic test, but it at least ensures that all dependencies are installed properly, and that the CPU architecture is correct.

Unfortunately, there are no test configs for OpenWRT 21.02, but testing for OpenWRT 22.03 is pretty close, and it's likely that all our packages will work for all OpenWRT versions.

See https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md#continuous-integration for more details.

These changes were adapted from the official OpenWRT/packages repo from https://github.com/openwrt/packages/tree/d36c34f9847d20450f61c955ccab745a5c90e90f used under the GPL-2.0 license.